### PR TITLE
Setting minSdkVersion to 4 to avoid implicit permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ android {
     compileSdkVersion 10
     buildToolsVersion "19.1.0"
 
+    defaultConfig {
+        minSdkVersion 4
+    }
+
     sourceSets {
         main {
             manifest.srcFile "parcelgen-runtime/AndroidManifest.xml"


### PR DESCRIPTION
With newer verisons of the gradle plugin, implicit permissions
are added when any used libraries support Apis < 4.
