### PR TITLE
Removed extra space in if statment

### DIFF
--- a/parcelgen.py
+++ b/parcelgen.py
@@ -573,7 +573,7 @@ class ParcelGen:
         output += self.tabify("return false;\n")
         self.downtab()
         output += self.tabify("}\n\n")
-        output += self.tabify("if (object == this ) {\n")
+        output += self.tabify("if (object == this) {\n")
         self.uptab()
         output += self.tabify("return true;\n")
         self.downtab()


### PR DESCRIPTION
Implementation of equals() had an extra space in the equals statement which has bene removed.