### PR TITLE
Parsing JsonList returns an empty list again.

### DIFF
--- a/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
+++ b/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
@@ -31,7 +31,7 @@ public class JsonUtil {
     public static <T extends Parcelable> ArrayList<T> parseJsonList(JSONArray array, JsonParser<T> creator)
             throws JSONException {
         if (array == null) {
-            return null;
+            return new ArrayList<T>();
         }
         int size = array.length();
         ArrayList<T> list = new ArrayList<T>(size);
@@ -52,7 +52,7 @@ public class JsonUtil {
     public static List<Boolean> parseBooleanJsonList(JSONArray array)
             throws JSONException {
         if (array == null) {
-            return null;
+            return new ArrayList<Boolean>();
         }
 
         int size = array.length();
@@ -67,7 +67,7 @@ public class JsonUtil {
     public static List<Double> parseDoubleJsonList(JSONArray array)
             throws JSONException {
         if (array == null) {
-            return null;
+            return new ArrayList<Double>();
         }
 
         int size = array.length();
@@ -82,7 +82,7 @@ public class JsonUtil {
     public static List<Integer> parseIntegerJsonList(JSONArray array)
             throws JSONException {
         if (array == null) {
-            return null;
+            return new ArrayList<Integer>();
         }
 
         int size = array.length();
@@ -97,7 +97,7 @@ public class JsonUtil {
     public static List<Long> parseLongJsonList(JSONArray array)
             throws JSONException {
         if (array == null) {
-            return null;
+            return new ArrayList<Long>();
         }
 
         int size = array.length();


### PR DESCRIPTION
https://github.com/Yelp/parcelgen/commit/d8ae8e34a11a5e846c81da3baade1786ccefdbca changed parseJsonList to return null instead of an empty list. However, this breaks existing implementations that expect an empty list. This change goes back to returning an empty list.