### PR TITLE
don’t use readBundle(), but readBundle(ClassLoader)

### DIFF
--- a/parcelgen.py
+++ b/parcelgen.py
@@ -354,7 +354,7 @@ class ParcelGen:
                         if map_type[1] in self.BOX_TYPES:
                             self.printtab("%s = source.readHashMap(%s.class.getClassLoader());" % (memberized, map_type[1]))
                         else:
-                            self.printtab("%s = JsonUtil.fromBundle(source.readBundle(), %s.class);" % (memberized, map_type[1]))
+                            self.printtab("%s = JsonUtil.fromBundle(source.readBundle(getClass().getClassLoader()), %s.class);" % (memberized, map_type[1]))
                     elif typ == "Date":
                         self.printtab("long date%d = source.readLong();" % i)
                         self.printtab("if (date%d != Integer.MIN_VALUE) {" % i)


### PR DESCRIPTION
This will fix the following Lint warning:

{{/Users/cjackson/src/biz-app/YelpBiz/src/main/java/com/yelp/android/biz/serializable/_BusinessAttributeData.java:59: Error: Using the default class loader will not work if you are restoring your own classes. Consider using for example readBundle(getClass().getClassLoader()) instead. [ParcelClassLoader]
mAttributesBoolChoice = JsonUtil.fromBundle(source.readBundle(), BoolAttributeChoice.class);