### PR TITLE
Fix parcelling of null Boxed arrays.

### DIFF
--- a/parcelgen.py
+++ b/parcelgen.py
@@ -118,7 +118,11 @@ class ParcelGen:
             return assignment
         elif classname in self.BOX_TYPES:
             assignment = self.tabify("Object[] %sObjArray = source.readArray(%s.class.getClassLoader());\n" % (memberized, classname))
+            assignment += self.tabify("if (%sObjArray != null) {\n" % (memberized))
+            self.uptab()
             assignment += self.tabify("%s = Arrays.copyOf(%sObjArray, %sObjArray.length, %s[].class);\n" % (memberized, memberized, memberized, classname))
+            self.downtab()
+            assignment += self.tabify("}\n")
             return assignment
         else:
             assignment = self.tabify("%s = source.createTypedArray(%s.CREATOR);\n" % (memberized, classname))


### PR DESCRIPTION
If the array was null the .length check would previously blow up.


Test code:
```java
@SmallTest
    @Test
    public void test_ArrayTest() throws Exception {
        YelpJsonObject json = new YelpJsonObject(getTestContext(), Weekly.DEFAULT);
        ArrrayTest testObj = ArrrayTest.CREATOR.parse(json);
        Parcel testParcel = Parcel.obtain();
        testObj.writeToParcel(testParcel, 0);
        testParcel.setDataPosition(0);
        ArrrayTest unparcelledItem = ArrrayTest.CREATOR.createFromParcel(testParcel);
        assertTrue("should be same", testObj.equals(unparcelledItem));
        testParcel.recycle();
    }
```

```json
{
  "do_json": true,
  "package": "com.yelp.android.serializable",
  "class_name": "_Test",
  "props": {
    "String": [
      "id",
      "text",
      "marketId",
      "marketName",
      "marketLocale",
      "headlinePhotoCreditName",
      "headlinePhotoTitle",
      "headlinePhotoUrl",
      "publishDate",
      "shareUrl"
    ],
    "String[]" : [
      "test"
    ],
    "YelpBusiness[]": [
      "businesses"
    ],
    "YelpBusinessReview[]": [
      "reviews"
    ],
    "WeeklySponsor": [
      "sponsor"
    ]
  }
}
```