### PR TITLE
Update buildToolsVersion to 25.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "com.android.library"
 android {
     publishNonDefault true
     compileSdkVersion 15
-    buildToolsVersion "19.1.0"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15


### PR DESCRIPTION
I checked that it would still compile if used with projects that are using an older buildToolsVersion