### PR TITLE
Update parcelgen-example tools versions.

### DIFF
--- a/parcelgen-example/build.gradle
+++ b/parcelgen-example/build.gradle
@@ -4,15 +4,15 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.yelp.parcelgen"


### PR DESCRIPTION
New versions required for Android Studio 3.0 compatibility.