### PR TITLE
Add support for two level nested maps

### DIFF
--- a/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
+++ b/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
@@ -170,8 +170,9 @@ public class JsonUtil {
     }
 
     /**
-     * @return A nested two level Map of the elements contained in object.
-     * The creator is used to parse template T. 
+     * @param object the input to parse.
+     * @param creator the creator class used to parse template T.
+     * @return a nested two level Map of the elements contained in object.
      */
     public static <T extends Parcelable> Map<String, Map<String, T>> parseTwoLevelJsonMap(
             JSONObject object, JsonParser<T> creator) throws JSONException {
@@ -248,8 +249,7 @@ public class JsonUtil {
     }
 
     /**
-     * Converts a two level nested map to a Bundle using toBundle as a helper
-     * method.
+     * Converts a two level nested map to a Bundle of Bundles.
      */
     public static <T extends Parcelable> Bundle toBundleTwoLevel(Map<String, Map<String, T>> input) {
         Bundle output = new Bundle();
@@ -269,8 +269,7 @@ public class JsonUtil {
     }
 
     /**
-     * Takes a Bundle of Bundles as input and outputs a two level nested map
-     * of input.  Utilizes fromBundle as a helper.
+     * Converts a Bundle of Bundles to a two level nested map.
      */
     public static <T> Map<String, Map<String, T>> fromBundleTwoLevel(Bundle input, Class<T> claz) {
         input.setClassLoader(claz.getClassLoader());

--- a/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
+++ b/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
@@ -10,7 +10,6 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -170,6 +169,17 @@ public class JsonUtil {
         return map;
     }
 
+    public static <T extends Parcelable> Map<String, Map<String, T>> parseTwoLevelJsonMap(
+            JSONObject object, JsonParser<T> creator) throws JSONException {
+        Map<String, Map<String, T>> nestedMap = new ArrayMap<String, Map<String, T>>();
+        Iterator<String> keys = object.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            nestedMap.put(key, parseJsonMap((JSONObject)object.get(key), creator));
+        }
+        return nestedMap;
+    }
+
     public static Map<String, Boolean> parseBooleanJsonMap(JSONObject object)
             throws JSONException {
         Map<String, Boolean> map = new ArrayMap<String, Boolean>();
@@ -233,11 +243,29 @@ public class JsonUtil {
         return output;
     }
 
+    public static <T extends Parcelable> Bundle toBundleTwoLevel(Map<String, Map<String, T>> input) {
+        Bundle output = new Bundle();
+        for (String key : input.keySet()) {
+            output.putParcelable(key, toBundle(input.get(key)));
+        }
+        return output;
+    }
+
     public static <T> Map<String, T> fromBundle(Bundle input, Class<T> claz) {
         input.setClassLoader(claz.getClassLoader());
         Map<String, T> output = new ArrayMap<String, T>();
         for(String key : input.keySet()) {
             output.put(key, (T) input.get(key));
+        }
+        return output;
+    }
+
+    public static <T> Map<String, Map<String, T>> fromBundleTwoLevel(Bundle input, Class<T> claz) {
+        input.setClassLoader(claz.getClassLoader());
+        Map<String, Map<String, T>> output = new ArrayMap<>();
+        for (String key : input.keySet()) {
+            Bundle bundle = (Bundle)input.get(key);
+            output.put(key, fromBundle(bundle, claz));
         }
         return output;
     }

--- a/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
+++ b/parcelgen-runtime/src/com/yelp/parcelgen/JsonUtil.java
@@ -169,6 +169,10 @@ public class JsonUtil {
         return map;
     }
 
+    /**
+     * @return A nested two level Map of the elements contained in object.
+     * The creator is used to parse template T. 
+     */
     public static <T extends Parcelable> Map<String, Map<String, T>> parseTwoLevelJsonMap(
             JSONObject object, JsonParser<T> creator) throws JSONException {
         Map<String, Map<String, T>> nestedMap = new ArrayMap<String, Map<String, T>>();
@@ -243,6 +247,10 @@ public class JsonUtil {
         return output;
     }
 
+    /**
+     * Converts a two level nested map to a Bundle using toBundle as a helper
+     * method.
+     */
     public static <T extends Parcelable> Bundle toBundleTwoLevel(Map<String, Map<String, T>> input) {
         Bundle output = new Bundle();
         for (String key : input.keySet()) {
@@ -260,6 +268,10 @@ public class JsonUtil {
         return output;
     }
 
+    /**
+     * Takes a Bundle of Bundles as input and outputs a two level nested map
+     * of input.  Utilizes fromBundle as a helper.
+     */
     public static <T> Map<String, Map<String, T>> fromBundleTwoLevel(Bundle input, Class<T> claz) {
         input.setClassLoader(claz.getClassLoader());
         Map<String, Map<String, T>> output = new ArrayMap<>();


### PR DESCRIPTION
Previously, we were missing support for parsing two level maps.  This adds support for generating the Java model code for parsing a two level maps as well as the necessary methods to JSONUtil.