### PR TITLE
Removed useless publishNonDefault directive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ repositories {
 apply plugin: "com.android.library"
 
 android {
-    publishNonDefault true
     compileSdkVersion 27
 
     defaultConfig {


### PR DESCRIPTION
Removing this directive since now is useless and is raising a warning on gradle builds:

```
> Configure project :parcelgen
publishNonDefault is deprecated and has no effect anymore. All variants are now published.
```